### PR TITLE
Fix auth config

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -8,7 +8,7 @@ server {
 
     location /api/ { # send to backend
         proxy_pass http://backend:5005;
-        proxy_set_header Authorization "Bearer $http_x_auth_request_access_token";
+        proxy_set_header Authorization "Bearer $http_x_forwarded_access_token";
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -34,15 +34,15 @@ spec:
         - environment: dev
           authentication:
             oauth2:
-              scope: openid profile email offline_access
+              scope: openid profile email offline_access api://a4f4519a-fafb-48c2-9a5c-3ba38309a824/co2specdemo.user
         - environment: test
           authentication:
             oauth2:
-              scope: openid profile email offline_access api://a4f4519a-fafb-48c2-9a5c-3ba38309a824/data_access
+              scope: openid profile email offline_access api://a4f4519a-fafb-48c2-9a5c-3ba38309a824/co2specdemo.user
         - environment: prod
           authentication:
             oauth2:
-              scope: openid profile email offline_access
+              scope: openid profile email offline_access api://a4f4519a-fafb-48c2-9a5c-3ba38309a824/co2specdemo.user
     - name: redis
       image: bitnami/redis:latest
       secrets:


### PR DESCRIPTION
This PR changes  nginx to use `http_x_forwarded_access_token` instead of `http_x_auth_request_access_token` as Authorization header when proxying requests to `/api` endpoints. It also updates the scope.